### PR TITLE
Enable WebGL, add eclipse support

### DIFF
--- a/src/main/java/MainActivity.java
+++ b/src/main/java/MainActivity.java
@@ -1,5 +1,6 @@
 package main.java;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -28,6 +29,7 @@ public class MainActivity extends Activity {
   private TextView pageLoadTime;
 
   @Override
+  @SuppressLint("NewApi")
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.main);
@@ -49,7 +51,6 @@ public class MainActivity extends Activity {
       WebView.setWebContentsDebuggingEnabled(true);
     }
     wv.setWebChromeClient(new WebChromeClient());
-    wv.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
     WebSettings settings = wv.getSettings();
     settings.setAllowUniversalAccessFromFileURLs(true);
     settings.setJavaScriptEnabled(true);


### PR DESCRIPTION
I noticed that WebGL wasn't enabled by default, which result in a low score on http://html5test.com.

Also, I was unable to build this project in Eclipse due to the "new API" warning.

This commit fixes both issues.

Before:

![before2](https://cloud.githubusercontent.com/assets/283842/6193951/f152b2a0-b38d-11e4-9060-04f0293617bf.png)

After:

![after2](https://cloud.githubusercontent.com/assets/283842/6193948/eddb51c2-b38d-11e4-8e97-c40b6b32d4f1.png)
